### PR TITLE
Add OIDC provider configuration for JWKS endpoint

### DIFF
--- a/identity_token.tf
+++ b/identity_token.tf
@@ -93,3 +93,13 @@ resource "vault_policy" "human-identity-token-policies" {
  }
  EOF
 }
+
+resource "vault_identity_oidc_provider" "default" {
+  name          = "default"
+  https_enabled = true
+  issuer_host   = "nginx:443"
+  allowed_client_ids = [
+    vault_identity_oidc_role.application_identity.client_id,
+    vault_identity_oidc_role.human_identity.client_id
+  ]
+}


### PR DESCRIPTION
- Add vault_identity_oidc_provider resource to expose public keys
- Configure provider with application and human identity client IDs
- Enable HTTPS and set issuer host to nginx:443
- This enables JWKS endpoint at /.well-known/keys